### PR TITLE
Removed 'Python' in 'Python Workshops'

### DIFF
--- a/pre-event/workshop/index.md
+++ b/pre-event/workshop/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-## Python Workshop Series (Upcoming, [**sign up here!**](https://forms.gle/wdzqCbVki58rj7da9)😄) 
+## 2020 Workshop Series (Upcoming, [**sign up here!**](https://forms.gle/wdzqCbVki58rj7da9)😄) 
 
 <div>
 <details>


### PR DESCRIPTION
not all workshops are python